### PR TITLE
Fix release date format in DefaultChangeRenderer

### DIFF
--- a/src/main/groovy/com/wooga/github/changelog/render/DefaultChangeRenderer.groovy
+++ b/src/main/groovy/com/wooga/github/changelog/render/DefaultChangeRenderer.groovy
@@ -46,7 +46,7 @@ class DefaultChangeRenderer<E extends ChangeSet<GHCommit, GHPullRequest>> implem
         Set<Link> links = new HashSet<Link>()
 
         new StringBuilder().with {
-            append(new Headline("${changes.name} - ${changes.date.format("YYYY-MM-D")}", 1, headlineType))
+            append(new Headline("${changes.name} - ${changes.date.format("YYYY-MM-dd")}", 1, headlineType))
             if (!changes.pullRequests.empty) {
                 append(new Headline("Pull Requests", 2, headlineType))
                 changes.pullRequests.each { pr ->

--- a/src/test/groovy/com/wooga/github/changelog/render/internal/DefaultChangeRendererSpec.groovy
+++ b/src/test/groovy/com/wooga/github/changelog/render/internal/DefaultChangeRendererSpec.groovy
@@ -142,6 +142,27 @@ class DefaultChangeRendererSpec extends Specification {
         pullRequestTitles.every { result.contains(it) }
     }
 
+    def "renders release date in form YYYY-MM-dd"() {
+        given: "a renderer"
+        renderer = new DefaultChangeRenderer<BaseChangeSet>()
+
+        and: "a name and date for the changeset"
+        testChangeset.name = releaseName
+        testChangeset.date = releaseDate
+
+        when:
+        def result = renderer.render(testChangeset)
+
+        then:
+        noExceptionThrown()
+        result.contains("# ${releaseName} - ${releaseDateString}")
+
+        where:
+        releaseName = "TestRelease"
+        releaseDate = new Date(0)
+        releaseDateString = releaseDate.format("YYYY-MM-dd")
+    }
+
     @Unroll
     def "renders #linkTo links #type style"() {
         given: "a renderer"


### PR DESCRIPTION
## Description

The renderer used a faulty format string which printed the days in year instead of the day in month. Simple patch plus a regression test.

## Changes

![FIX] date formate in `DefaultChangeRenderer`

[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"