### PR TITLE
Fix crash when fetched changelog is empty

### DIFF
--- a/src/main/groovy/com/wooga/github/changelog/DefaultChangeDetector.groovy
+++ b/src/main/groovy/com/wooga/github/changelog/DefaultChangeDetector.groovy
@@ -108,12 +108,13 @@ class DefaultChangeDetector implements ChangeDetector<BaseChangeSet<GHCommit, GH
         }
 
         commits = commits.subList(startIndex, endIndex)
+        List<GHPullRequest> pullRequests = []
 
-        assert commits.first().getSHA1() == to.getSHA1()
-
-        commits = filterUnrelatedCommits(commits)
-
-        List<GHPullRequest> pullRequests = fetchPullRequestsFromCommits(client, hub, commits, branchName)
+        if(!commits.empty) {
+            assert commits.first().getSHA1() == to.getSHA1()
+            commits = filterUnrelatedCommits(commits)
+            pullRequests = fetchPullRequestsFromCommits(client, hub, commits, branchName)
+        }
 
         new BaseChangeSet(hub.fullName, from.toString(), to.toString(), commits, pullRequests)
     }

--- a/src/test/groovy/com/wooga/github/changelog/internal/ChangeDetectorSpec.groovy
+++ b/src/test/groovy/com/wooga/github/changelog/internal/ChangeDetectorSpec.groovy
@@ -121,6 +121,7 @@ class ChangeDetectorSpec extends Specification {
         "v0.2.0-rc.1" | "v0.2.0-rc.2" | 8           | 1          | "develop"
         "v0.1.0"      | "v0.1.1"      | 14          | 2          | testRepo.repository.defaultBranch
         "v0.1.0"      | "v0.1.1"      | 14          | 2          | "develop"
+        "v0.2.0"      | null          | 0           | 0          | testRepo.repository.defaultBranch
     }
 
     String commitShaForCommit(int commitNumber) {


### PR DESCRIPTION
## Description

The `DefaultChangeDetector` has a bug that it tries to access the first element of the fetched git changelog even though it can be empty. I added a simple guard to prevent further processing when the fetched log is empty. This can happen when `HEAD` == the from tagname.

## Changes

* ![FIX] crash when fetched changelog is empty

[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"