### PR TITLE
Improve commit range validation

### DIFF
--- a/src/main/groovy/com/wooga/github/changelog/internal/ChangeDetectorException.groovy
+++ b/src/main/groovy/com/wooga/github/changelog/internal/ChangeDetectorException.groovy
@@ -18,8 +18,29 @@
 package com.wooga.github.changelog.internal
 
 import groovy.transform.InheritConstructors
+import org.kohsuke.github.GHCommit
+import org.kohsuke.github.GHTag
+import org.kohsuke.github.GHTagObject
 
 @InheritConstructors
 class ChangeDetectorException extends Exception {
-
 }
+
+class CommitNotReachableException extends ChangeDetectorException {
+    final GHCommit commit
+
+    CommitNotReachableException(GHCommit commit, String message) {
+        super(message)
+        this.commit = commit
+    }
+}
+
+class TagNotReachableException extends ChangeDetectorException {
+    final GHTag tag
+
+    TagNotReachableException(GHTag tag, String message, Throwable cause) {
+        super(message, cause)
+        this.tag = tag
+    }
+}
+


### PR DESCRIPTION
Description
===========

It is possible to provide a valid tag name or commit sha as _from_ and _to_ parameters. The resulting commits are checked if they are available but not if they are reachable from the provided branch.

```
NR
9         * commit 4 on develop
8         * commit 3 on develop
7       * | commit 5 (tag: v0.1.1)
6       * | commit 4
5       | * commit 2 on develop
4       * | commit 3 (tag: v0.1.0)
3       | * commit 1 on develop
        |/
2       * commit 2
1       * Initial commit
```

One could call `changeDetector.detectChangesFromTag('v0.1.0', 'v0.1.1', 'develop')` or with the commit SHA's and the function would fail with an generic `java.lang.IllegalArgumentException`. This patch adds a range check for the provided parameters and throws a more meaningfill exception.

Changes
=======

* ![IMPROVE] range validation for provided from/to parameters

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
