### PR TITLE
Remove grgit as compile time dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,8 @@ if (cliTasks.contains("rc")) {
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.15'
     compile 'org.kohsuke:github-api:1.95'
-    compile "org.ajoberstar:gradle-git:1.7.2"
     compile 'org.apache.commons:commons-io:+'
+    testCompile 'org.ajoberstar.grgit:grgit-core:4.0.2'
     testCompile 'org.spockframework:spock-core:1.2-groovy-2.4'
     testCompile 'com.wooga.spock.extensions:spock-github-extension:0.1.0'
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'


### PR DESCRIPTION
## Description

This library doesn't need grgit as a compile/runtime dependency. Only the tests need this dependency to setup the test repositories.

## Changes

* ![REMOVE] `grgit` from compile configuration
* ![UPDATE] `grgit` to latest release

[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"