### PR TITLE
Add generic detect changes method

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,26 +2,12 @@
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
 withCredentials([usernamePassword(credentialsId: 'github_integration', passwordVariable: 'githubPassword', usernameVariable: 'githubUser'),
-                 usernamePassword(credentialsId: 'github_integration_2', passwordVariable: 'githubPassword2', usernameVariable: 'githubUser2'),
-                 usernamePassword(credentialsId: 'github_integration_3', passwordVariable: 'githubPassword3', usernameVariable: 'githubUser3'),
                  string(credentialsId: 'github_changelog_lib_coveralls_token', variable: 'coveralls_token')]) {
 
-    def testEnvironment = [ 'osx':
-                               [
-                                   "ATLAS_GITHUB_INTEGRATION_USER=${githubUser}",
-                                   "ATLAS_GITHUB_INTEGRATION_PASSWORD=${githubPassword}"
-                               ],
-                             'windows':
-                               [
-                                   "ATLAS_GITHUB_INTEGRATION_USER=${githubUser2}",
-                                   "ATLAS_GITHUB_INTEGRATION_PASSWORD=${githubPassword2}"
-                               ],
-                             'linux':
-                               [
-                                   "ATLAS_GITHUB_INTEGRATION_USER=${githubUser3}",
-                                   "ATLAS_GITHUB_INTEGRATION_PASSWORD=${githubPassword3}"
-                               ]
-                        ]
+    def testEnvironment = [
+                               "ATLAS_GITHUB_INTEGRATION_USER=${githubUser}",
+                               "ATLAS_GITHUB_INTEGRATION_PASSWORD=${githubPassword}"
+                          ]
 
-    buildJavaLibrary plaforms: ['osx','windows','linux'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
+    buildJavaLibrary plaforms: ['linux'], coverallsToken: coveralls_token, testEnvironment: testEnvironment
 }

--- a/src/main/groovy/com/wooga/github/changelog/ChangeDetector.groovy
+++ b/src/main/groovy/com/wooga/github/changelog/ChangeDetector.groovy
@@ -20,6 +20,8 @@ package com.wooga.github.changelog
 import com.wooga.github.changelog.internal.ChangeDetectorException
 
 interface ChangeDetector<B> {
+    B detectChanges(String fromCommitish, String toCommitish) throws ChangeDetectorException
+    B detectChanges(String fromCommitish, String toCommitish, String branchName) throws ChangeDetectorException
     B detectChangesFromShaToHead(String from) throws ChangeDetectorException
     B detectChangesFromShaToHead(String from, String branchName) throws ChangeDetectorException
     B detectChangesFromSha(String from, String to) throws ChangeDetectorException

--- a/src/test/groovy/com/wooga/github/changelog/internal/ChangeDetectorSpec.groovy
+++ b/src/test/groovy/com/wooga/github/changelog/internal/ChangeDetectorSpec.groovy
@@ -220,6 +220,58 @@ class ChangeDetectorSpec extends Specification {
         "v0.2.0"      | null          | 0           | 0          | testRepo.repository.defaultBranch
     }
 
+    @Unroll
+    def "detect changes from commitish #from to commitish #to with #changesLogs commits and #changesPRs pull requests and branch #branch"() {
+        given: "a detector"
+        changeDetector = new DefaultChangeDetector(testRepo.client, testRepo.repository)
+
+        and: "a sha based on the from number"
+        if (from instanceof Integer) {
+            from = commitShaForCommit(from)
+        }
+
+        and: "a sha based on the to number"
+        if (to instanceof Integer) {
+            to = commitShaForCommit(to)
+        }
+
+        when:
+        def changes = changeDetector.detectChanges(from, to, branch)
+
+        then:
+        changes.logs.size() == changesLogs
+        changes.pullRequests.size() == changesPRs
+
+        where:
+        from          | to            | changesLogs | changesPRs | branch
+        null          | null          | 30          | 3          | testRepo.repository.defaultBranch
+        null          | null          | 29          | 3          | "develop"
+        "v0.1.0"      | null          | 24          | 3          | "develop"
+        "v0.1.0"      | null          | 25          | 3          | testRepo.repository.defaultBranch
+        "v0.1.0"      | "v0.2.0-rc.1" | 12          | 2          | "develop"
+        "v0.2.0-rc.1" | "v0.2.0-rc.2" | 8           | 1          | testRepo.repository.defaultBranch
+        "v0.2.0-rc.1" | "v0.2.0-rc.2" | 8           | 1          | "develop"
+        "v0.1.0"      | "v0.1.1"      | 14          | 2          | testRepo.repository.defaultBranch
+        "v0.1.0"      | "v0.1.1"      | 14          | 2          | "develop"
+        "v0.2.0"      | null          | 0           | 0          | testRepo.repository.defaultBranch
+        0             | 0             | 30          | 3          | testRepo.repository.defaultBranch
+        0             | 0             | 29          | 3          | "develop"
+        5             | 0             | 24          | 3          | "develop"
+        5             | 0             | 25          | 3          | testRepo.repository.defaultBranch
+        5             | 21            | 12          | 2          | "develop"
+        21            | 29            | 8           | 1          | testRepo.repository.defaultBranch
+        21            | 29            | 8           | 1          | "develop"
+        5             | 25            | 14          | 2          | testRepo.repository.defaultBranch
+        5             | 25            | 14          | 2          | "develop"
+        "fix/one"     | null          | 20          | 3          | testRepo.repository.defaultBranch
+        "fix/one"     | "master"      | 20          | 3          | testRepo.repository.defaultBranch
+        "fix/one"     | "fix/two"     | 8           | 1          | testRepo.repository.defaultBranch
+        11            | "v0.1.1"      | 8           | 1          | testRepo.repository.defaultBranch
+        "v0.2.0"      | "master"      | 0           | 0          | testRepo.repository.defaultBranch
+        11            | "master"      | 19          | 2          | testRepo.repository.defaultBranch
+    }
+
+
     String commitShaForCommit(int commitNumber) {
         if (commitNumber == 0) {
             return null


### PR DESCRIPTION
## Description

This patch adds a new method:
`B detectChanges(String fromCommitish, String toCommitish, String branchName) throws ChangeDetectorException`

The implementation allows to pass anything that can be converted into a commit to be passed as `from` and `to`. At the moment _tag name_, _branche name_ and _commit sha_ values are supported. This comes with a slight performance and API call overhead because the implementation needs to check multiple endpoints if the provided value can be converted into a tag or branch.

## Description

* ![ADD] generic detect changes method

[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"