### PR TITLE
Fix Stack overflow on very large git graphs

### DIFF
--- a/src/test/groovy/com/wooga/github/changelog/internal/ChangeDetectorSpec.groovy
+++ b/src/test/groovy/com/wooga/github/changelog/internal/ChangeDetectorSpec.groovy
@@ -355,7 +355,7 @@ class ChangeDetectorSpec extends Specification {
         fromNumber | toNumber | explaination                            | type                          | messagePattern
         21         | 25       | "from sha is not an ancestor of to sha" | ChangeDetectorException.class | /.* are not connected/
         25         | 21       | "from sha is younger than to sha"       | ChangeDetectorException.class | /.* is newer than .*/
-        88         | 29       | "from sha does no exist"                | HttpException.class           | /.*No commit found for SHA: .*/
-        21         | 90       | "to tag does no exist"                  | HttpException.class           | /.*No commit found for SHA: .*/
+        200        | 29       | "from sha does not exist"                | HttpException.class           | /.*No commit found for SHA: .*/
+        21         | 800      | "to tag does not exist"                  | HttpException.class           | /.*No commit found for SHA: .*/
     }
 }

--- a/src/test/groovy/com/wooga/github/changelog/internal/RepoLayoutPresets.groovy
+++ b/src/test/groovy/com/wooga/github/changelog/internal/RepoLayoutPresets.groovy
@@ -24,8 +24,6 @@ import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Person
 import org.ajoberstar.grgit.operation.MergeOp
 
-import java.util.stream.IntStream
-
 class RepoLayoutPresets {
 
     static void worstCaseRepoWithHighBranching(Repository repo, int merges) {

--- a/src/test/groovy/com/wooga/github/changelog/internal/RepoLayoutPresets.groovy
+++ b/src/test/groovy/com/wooga/github/changelog/internal/RepoLayoutPresets.groovy
@@ -24,6 +24,8 @@ import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Person
 import org.ajoberstar.grgit.operation.MergeOp
 
+import java.util.stream.IntStream
+
 class RepoLayoutPresets {
 
     static void worstCaseRepoWithHighBranching(Repository repo, int merges) {
@@ -103,6 +105,7 @@ class RepoLayoutPresets {
         git.checkout(branch: "develop")
         git.commit(message: "commit 3 on develop")
         git.commit(message: "commit 4 on develop")
+
         git.push(remote: "origin", all: true)
     }
 
@@ -248,6 +251,7 @@ class RepoLayoutPresets {
 
         repo.createRelease("0.2.0", "v0.2.0")
         git.pull(rebase:true, branch: repo.defaultBranch.name)
+
         println("")
     }
 


### PR DESCRIPTION
Game teams detected that when executing over large git graphs, the plugin would throw a `StackOverflowError`. This happens when the plugin tries to search if a given commit is connected to the head (`DefaultChangeDetector.isConnectedToHead`), as it iterated recursively through the git graph. As Java does not support tail recursion, in large graphs the recursion stack accumulation leads to a stack overflow.

The solution for this was to change the `DefaultChangeDetector.isConnectedToHead` method to a non-recursive implementation.


## Description

![FIX] fixed bug where stack would overflow on large git graphs.

[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
