### PR TITLE
Fix fetch commits after github API update

### DIFF
--- a/src/main/groovy/com/wooga/github/changelog/DefaultChangeDetector.groovy
+++ b/src/main/groovy/com/wooga/github/changelog/DefaultChangeDetector.groovy
@@ -287,10 +287,10 @@ class DefaultChangeDetector implements ChangeDetector<BaseChangeSet<GHCommit, GH
         builder.from(branchName)
 
         if (from) {
-            builder.since(githubDate(from))
+            builder.since(from)
         }
         if (to) {
-            builder.until(githubDate(to))
+            builder.until(to)
         }
 
         builder.list().collect()


### PR DESCRIPTION
## Description

The github Java API broke slightly after the latest update. We used to normalize the commit dates to UTC before passing them to the API. The github API is now handling this themselves and so it broke the unit/integration tests as a timeframe of 2h (berlin local time) is already enough to break most tests. We still need the normalization to fetch the pullrequests because we use the query API directly and because the commit dates handed down from the API are in local time again.

## Changes

* ![FIX] fetch committs after github API update

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
